### PR TITLE
Feature/caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Editors
 .idea/
 *.iml
+
+docker-compose.override.yml

--- a/database/init.sql
+++ b/database/init.sql
@@ -12,6 +12,13 @@ create table pangolin_lineage_alias
 );
 
 
+create table data_version
+(
+  dataset text primary key,
+  timestamp bigint not null
+);
+
+
 -- Source: Nextstrain/GenBank
 
 create table y_nextstrain_genbank
@@ -179,6 +186,7 @@ create table y_main_aa_sequence_columnar
 grant select, insert, update, delete, references, truncate
 on
   pangolin_lineage_alias,
+  data_version,
   y_nextstrain_genbank,
 --   y_gisaid,
   y_main_metadata,

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -25,4 +25,5 @@ services:
       - 127.0.0.1:6789:6379
     volumes:
       - <path>/redis.conf:/usr/local/etc/redis/redis.conf
+      - <path>/redis-data:/data
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+
+  lapis_server:
+    image: ghcr.io/cevo-public/lapis-server:public
+    container_name: lapis_server
+    restart: unless-stopped
+    depends_on:
+      - lapis_redis
+    ports:
+      - 2345:2345
+    volumes:
+      - <path>/lapis-config.yml:/app/lapis-config.yml
+  lapis_docs:
+    image: ghcr.io/cevo-public/lapis-docs:public
+    container_name: lapis_docs
+    restart: unless-stopped
+    ports:
+      - 4567:4567
+  lapis_redis:
+    image: redis:6
+    container_name: lapis_redis
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:6789:6379
+    volumes:
+      - <path>/redis.conf:/usr/local/etc/redis/redis.conf
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,0 +1,1 @@
+LAPIS uses [redis](https://redis.io/) to cache API responses.

--- a/redis/redis.conf
+++ b/redis/redis.conf
@@ -1,0 +1,2 @@
+maxmemory 2gb
+maxmemory-policy allkeys-lru

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile 'com.googlecode.json-simple:json-simple:1.1.1'
     compile 'org.simplejavamail:simple-java-mail:6.5.3'
     compile 'org.jooq:jooq:3.14.8'
+    compile 'redis.clients:jedis:3.7.0'
 
     testCompile 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/server/src/main/java/ch/ethz/lapis/LapisConfig.java
+++ b/server/src/main/java/ch/ethz/lapis/LapisConfig.java
@@ -27,6 +27,8 @@ public class LapisConfig implements Config {
 
     private Source source;
 
+    private Boolean cacheEnabled;
+
 
     public DatabaseConfig getVineyard() {
         return vineyard;
@@ -97,6 +99,15 @@ public class LapisConfig implements Config {
 
     public LapisConfig setSource(Source source) {
         this.source = source;
+        return this;
+    }
+
+    public Boolean getCacheEnabled() {
+        return cacheEnabled;
+    }
+
+    public LapisConfig setCacheEnabled(Boolean cacheEnabled) {
+        this.cacheEnabled = cacheEnabled;
         return this;
     }
 }

--- a/server/src/main/java/ch/ethz/lapis/LapisMain.java
+++ b/server/src/main/java/ch/ethz/lapis/LapisMain.java
@@ -9,14 +9,17 @@ import ch.ethz.lapis.transform.TransformService;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.Arrays;
 import java.util.Collections;
 
 @SpringBootApplication
+@EnableScheduling
 public class LapisMain extends SubProgram<LapisConfig> {
 
     public static LapisConfig globalConfig;
+    public static ComboPooledDataSource dbPool;
 
     public LapisMain() {
         super("Lapis", LapisConfig.class);
@@ -28,6 +31,7 @@ public class LapisMain extends SubProgram<LapisConfig> {
             throw new RuntimeException("TODO: write help page");
         }
         globalConfig = config;
+        dbPool = DatabaseService.createDatabaseConnectionPool(LapisMain.globalConfig.getVineyard());
         GlobalProxyManager.setProxyFromConfig(config.getHttpProxy());
         if ("--api".equals(args[0])) {
             String[] argsForSpring = Arrays.copyOfRange(args, 1, args.length);

--- a/server/src/main/java/ch/ethz/lapis/api/CacheService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/CacheService.java
@@ -1,26 +1,66 @@
 package ch.ethz.lapis.api;
 
+import ch.ethz.lapis.api.controller.v0.SampleController;
 import ch.ethz.lapis.api.entity.ApiCacheKey;
+import ch.ethz.lapis.api.entity.req.SampleAggregatedRequest;
+import ch.ethz.lapis.api.entity.req.SampleDetailRequest;
 import ch.ethz.lapis.util.DeflateSeqCompressor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.args.FlushMode;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 
 @Service
 public class CacheService {
 
+    public static final class SupportedEndpoints {
+        public static final String SAMPLE_AGGREGATED = "/v0/sample/aggregated";
+        public static final String SAMPLE_AA_MUTATIONS = "/v0/sample/aa-mutations";
+        public static final String SAMPLE_NUC_MUTATIONS = "/v0/sample/nuc-mutations";
+    }
+
+    private static final Map<String, Class<?>> endpointToClass = new HashMap<>() {{
+        put(SupportedEndpoints.SAMPLE_AGGREGATED, SampleAggregatedRequest.class);
+        put(SupportedEndpoints.SAMPLE_AA_MUTATIONS, SampleDetailRequest.class);
+        put(SupportedEndpoints.SAMPLE_NUC_MUTATIONS, SampleDetailRequest.class);
+    }};
+
+    private static final Map<String, BiConsumer<SampleController, Object>> endpointToPreComputation = new HashMap<>() {{
+        put(SupportedEndpoints.SAMPLE_AGGREGATED, (sampleController, obj) ->  {
+            SampleAggregatedRequest request = (SampleAggregatedRequest) obj;
+            sampleController.getAggregated(request);
+        });
+        put(SupportedEndpoints.SAMPLE_AA_MUTATIONS, (sampleController, obj) ->  {
+            SampleDetailRequest request = (SampleDetailRequest) obj;
+            sampleController.getAAMutations(request);
+        });
+        put(SupportedEndpoints.SAMPLE_NUC_MUTATIONS, (sampleController, obj) ->  {
+            SampleDetailRequest request = (SampleDetailRequest) obj;
+            sampleController.getNucMutations(request);
+        });
+    }};
+
     private final JedisPool pool = new JedisPool("127.0.0.1", 6789);
     private final ObjectMapper objectMapper;
     private final DeflateSeqCompressor compressor;
+    private final SampleController sampleController;
 
 
-    public CacheService() {
+    public CacheService(@Lazy SampleController sampleController) {
+        this.sampleController = sampleController;
         objectMapper = new ObjectMapper();
         objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         compressor = new DeflateSeqCompressor(DeflateSeqCompressor.DICT.NONE);
@@ -28,30 +68,113 @@ public class CacheService {
 
 
     public String getCompressedString(ApiCacheKey cacheKey) {
-        try {
-            String keyString = objectMapper.writeValueAsString(cacheKey);
-            try (Jedis jedis = pool.getResource()) {
-                byte[] compressed = jedis.get(keyString.getBytes(StandardCharsets.UTF_8));
-                if (compressed == null) {
-                    return null;
-                }
-                return compressor.decompress(compressed);
+        String keyString = apiCacheKeyToString(cacheKey);
+        try (Jedis jedis = pool.getResource()) {
+            byte[] compressed = jedis.get(keyString.getBytes(StandardCharsets.UTF_8));
+            if (compressed == null) {
+                return null;
             }
+            return compressor.decompress(compressed);
+        }
+    }
+
+
+    public void setCompressedString(ApiCacheKey cacheKey, String value) {
+        String keyString = apiCacheKeyToString(cacheKey);
+        byte[] compressed = compressor.compress(value);
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set(keyString.getBytes(StandardCharsets.UTF_8), compressed);
+        }
+    }
+
+
+    public Long getLong(String cacheKey) {
+        try (Jedis jedis = pool.getResource()) {
+            String s = jedis.get(cacheKey);
+            if (s == null) {
+                return null;
+            }
+            return Long.parseLong(s);
+        }
+    }
+
+
+    public void setLong(String cacheKey, long value) {
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set(cacheKey, String.valueOf(value));
+        }
+    }
+
+
+    /**
+     * Clear the cache and recalculate values for all keys if the cache is out-dated.
+     */
+    public void updateCacheIfOutdated(long newDataVersion) {
+        Long currentDataVersion = getCacheDataVersion();
+        if (currentDataVersion != null && currentDataVersion == newDataVersion) {
+            return;
+        }
+        List<String> keys = getAllApiKeys();
+        try (Jedis jedis = pool.getResource()) {
+            jedis.flushAll(FlushMode.SYNC);
+        }
+        setCacheDataVersion(newDataVersion);
+
+        // Pre-compute
+        new Thread(() -> {
+            preCompute(keys);
+        }).start();
+    }
+
+
+    private List<String> getAllApiKeys() {
+        try (Jedis jedis = pool.getResource()) {
+            Set<byte[]> keysBytes = jedis.keys("api###*".getBytes(StandardCharsets.UTF_8));
+            return keysBytes.stream()
+                    .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                    .collect(Collectors.toList());
+        }
+    }
+
+
+    private String apiCacheKeyToString(ApiCacheKey cacheKey) {
+        try {
+            return "api###" + cacheKey.getEndpointName() + "###"
+                    + objectMapper.writeValueAsString(cacheKey.getRequestObject());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
     }
 
 
-    public void setCompressedString(ApiCacheKey cacheKey, String value) {
-        try {
-            String keyString = objectMapper.writeValueAsString(cacheKey);
-            byte[] compressed = compressor.compress(value);
-            try (Jedis jedis = pool.getResource()) {
-                jedis.set(keyString.getBytes(StandardCharsets.UTF_8), compressed);
+    private Long getCacheDataVersion() {
+        return getLong("general###data_version");
+    }
+
+
+    private void setCacheDataVersion(long dataVersion) {
+        setLong("general###data_version", dataVersion);
+    }
+
+
+    private void preCompute(List<String> keys) {
+        int i = 0;
+        for (String key : keys) {
+            i++;
+            try {
+                if (!key.startsWith("api###")) {
+                    break;
+                }
+                String subKey = key.substring(6);
+                String[] split = subKey.split("###", 2);
+                String endpoint = split[0];
+                String requestJson = split[1];
+                System.out.println("Pre-computing " +  "(" + i + "/" + keys.size() + ") - " + subKey);
+                Object request = objectMapper.readValue(requestJson, endpointToClass.get(endpoint));
+                endpointToPreComputation.get(endpoint).accept(sampleController, request);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
             }
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/server/src/main/java/ch/ethz/lapis/api/CacheService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/CacheService.java
@@ -1,0 +1,58 @@
+package ch.ethz.lapis.api;
+
+import ch.ethz.lapis.api.entity.ApiCacheKey;
+import ch.ethz.lapis.util.DeflateSeqCompressor;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.stereotype.Service;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.nio.charset.StandardCharsets;
+
+
+@Service
+public class CacheService {
+
+    private final JedisPool pool = new JedisPool("127.0.0.1", 6789);
+    private final ObjectMapper objectMapper;
+    private final DeflateSeqCompressor compressor;
+
+
+    public CacheService() {
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+        compressor = new DeflateSeqCompressor(DeflateSeqCompressor.DICT.NONE);
+    }
+
+
+    public String getCompressedString(ApiCacheKey cacheKey) {
+        try {
+            String keyString = objectMapper.writeValueAsString(cacheKey);
+            try (Jedis jedis = pool.getResource()) {
+                byte[] compressed = jedis.get(keyString.getBytes(StandardCharsets.UTF_8));
+                if (compressed == null) {
+                    return null;
+                }
+                return compressor.decompress(compressed);
+            }
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public void setCompressedString(ApiCacheKey cacheKey, String value) {
+        try {
+            String keyString = objectMapper.writeValueAsString(cacheKey);
+            byte[] compressed = compressor.compress(value);
+            try (Jedis jedis = pool.getResource()) {
+                jedis.set(keyString.getBytes(StandardCharsets.UTF_8), compressed);
+            }
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/server/src/main/java/ch/ethz/lapis/api/CacheService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/CacheService.java
@@ -8,6 +8,7 @@ import ch.ethz.lapis.util.DeflateSeqCompressor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import redis.clients.jedis.Jedis;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 
 
 @Service
+@Conditional(IsCacheEnabledCondition.class)
 public class CacheService {
 
     public static final class SupportedEndpoints {

--- a/server/src/main/java/ch/ethz/lapis/api/DataVersionService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/DataVersionService.java
@@ -9,19 +9,20 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Optional;
 
 
 @Service
 public class DataVersionService {
 
     private static final ComboPooledDataSource dbPool = LapisMain.dbPool;
-    private final CacheService cacheService;
+    private final Optional<CacheService> cacheServiceOpt;
 
     private long version = -1;
 
 
-    public DataVersionService(CacheService cacheService) {
-        this.cacheService = cacheService;
+    public DataVersionService(Optional<CacheService> cacheServiceOpt) {
+        this.cacheServiceOpt = cacheServiceOpt;
         autoFetchVersionDate();
     }
 
@@ -49,7 +50,9 @@ public class DataVersionService {
                         // Update the cache
                         System.out.println("New data version: " + version + " -> " + newVersion);
                         version = newVersion;
-                        cacheService.updateCacheIfOutdated(version);
+                        if (cacheServiceOpt.isPresent()) {
+                            cacheServiceOpt.get().updateCacheIfOutdated(version);
+                        }
                     }
                 }
             }

--- a/server/src/main/java/ch/ethz/lapis/api/DataVersionService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/DataVersionService.java
@@ -1,0 +1,61 @@
+package ch.ethz.lapis.api;
+
+import ch.ethz.lapis.LapisMain;
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+
+@Service
+public class DataVersionService {
+
+    private static final ComboPooledDataSource dbPool = LapisMain.dbPool;
+    private final CacheService cacheService;
+
+    private long version = -1;
+
+
+    public DataVersionService(CacheService cacheService) {
+        this.cacheService = cacheService;
+        autoFetchVersionDate();
+    }
+
+
+    public long getVersion() {
+        return version;
+    }
+
+
+    @Scheduled(fixedDelay = 1000)
+    public void autoFetchVersionDate() {
+        String sql = """
+            select timestamp
+            from data_version
+            where dataset = 'merged';
+        """;
+        try (Connection conn = dbPool.getConnection()) {
+            try (Statement statement = conn.createStatement()) {
+                try (ResultSet rs = statement.executeQuery(sql)) {
+                    if (!rs.next()) {
+                        throw new RuntimeException("The data version cannot be found in the database.");
+                    }
+                    long newVersion = rs.getLong("timestamp");
+                    if (newVersion != version) {
+                        // Update the cache
+                        System.out.println("New data version: " + version + " -> " + newVersion);
+                        version = newVersion;
+                        cacheService.updateCacheIfOutdated(version);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/server/src/main/java/ch/ethz/lapis/api/IsCacheEnabledCondition.java
+++ b/server/src/main/java/ch/ethz/lapis/api/IsCacheEnabledCondition.java
@@ -1,0 +1,15 @@
+package ch.ethz.lapis.api;
+
+import ch.ethz.lapis.LapisMain;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+
+public class IsCacheEnabledCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        Boolean cacheEnabled = LapisMain.globalConfig.getCacheEnabled();
+        return cacheEnabled != null && cacheEnabled;
+    }
+}

--- a/server/src/main/java/ch/ethz/lapis/api/SampleService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/SampleService.java
@@ -34,8 +34,7 @@ import java.util.stream.Collectors;
 @Service
 public class SampleService {
 
-    private static final ComboPooledDataSource dbPool
-            = DatabaseService.createDatabaseConnectionPool(LapisMain.globalConfig.getVineyard());
+    private static final ComboPooledDataSource dbPool = LapisMain.dbPool;
     private static final SeqCompressor referenceSeqCompressor
             = new DeflateSeqCompressor(DeflateSeqCompressor.DICT.REFERENCE);
     private static final SeqCompressor nucMutationColumnarCompressor

--- a/server/src/main/java/ch/ethz/lapis/api/controller/v0/HelloController.java
+++ b/server/src/main/java/ch/ethz/lapis/api/controller/v0/HelloController.java
@@ -1,10 +1,12 @@
 package ch.ethz.lapis.api.controller.v0;
 
-import ch.ethz.lapis.api.entity.res.V0Response;
 import ch.ethz.lapis.api.entity.res.SimpleMessage;
+import ch.ethz.lapis.api.entity.res.V0Response;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
 
 @RestController
 @RequestMapping("/v0")
@@ -13,7 +15,7 @@ public class HelloController {
     @GetMapping("")
     public V0Response<SimpleMessage> getDataStatus() {
         String s = "This is LAPIS. Please see https://cov-spectrum.ethz.ch/public for more information";
-        return new V0Response<>(new SimpleMessage(s));
+        return new V0Response<>(new SimpleMessage(s), Instant.now().getEpochSecond());
     }
 
 }

--- a/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
+++ b/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
@@ -24,9 +24,7 @@ public class SampleController {
 
     @GetMapping("/aggregated")
     public V0Response<SampleAggregatedResponse> getAggregated(SampleAggregatedRequest request) throws SQLException {
-        long start = System.currentTimeMillis();
         List<SampleAggregated> aggregatedSamples = sampleService.getAggregatedSamples(request);
-        System.out.println("E2E: " + (System.currentTimeMillis() - start));
         return new V0Response<>(new SampleAggregatedResponse(
                 request.getFields(),
                 aggregatedSamples
@@ -35,9 +33,7 @@ public class SampleController {
 
     @GetMapping("/details")
     public V0Response<SampleDetailResponse> getDetails(SampleDetailRequest request) throws SQLException {
-        long start = System.currentTimeMillis();
         List<SampleDetail> samples = sampleService.getDetailedSamples(request);
-        System.out.println("E2E: " + (System.currentTimeMillis() - start));
         return new V0Response<>(new SampleDetailResponse(samples));
     }
 
@@ -58,10 +54,7 @@ public class SampleController {
             produces = "text/x-fasta"
     )
     public String getFasta(SampleDetailRequest request) throws SQLException {
-        long start = System.currentTimeMillis();
-        String fasta = sampleService.getFasta(request, false);
-        System.out.println("E2E: " + (System.currentTimeMillis() - start));
-        return fasta;
+        return sampleService.getFasta(request, false);
     }
 
     @GetMapping(
@@ -69,10 +62,7 @@ public class SampleController {
             produces = "text/x-fasta"
     )
     public String getAlignedFasta(SampleDetailRequest request) throws SQLException {
-        long start = System.currentTimeMillis();
-        String fasta = sampleService.getFasta(request, true);
-        System.out.println("E2E: " + (System.currentTimeMillis() - start));
-        return fasta;
+        return sampleService.getFasta(request, true);
     }
 
 }

--- a/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
+++ b/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
@@ -5,6 +5,8 @@ import ch.ethz.lapis.api.entity.SequenceType;
 import ch.ethz.lapis.api.entity.req.SampleAggregatedRequest;
 import ch.ethz.lapis.api.entity.req.SampleDetailRequest;
 import ch.ethz.lapis.api.entity.res.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,36 +19,54 @@ import java.util.List;
 public class SampleController {
 
     private final SampleService sampleService;
+    private final ObjectMapper objectMapper;
 
-    public SampleController(SampleService sampleService) {
+    public SampleController(SampleService sampleService, ObjectMapper objectMapper) {
         this.sampleService = sampleService;
+        this.objectMapper = objectMapper;
     }
 
-    @GetMapping("/aggregated")
-    public V0Response<SampleAggregatedResponse> getAggregated(SampleAggregatedRequest request) throws SQLException {
+    @GetMapping(
+            value = "/aggregated",
+            produces = "application/json"
+    )
+    public String getAggregated(SampleAggregatedRequest request) throws SQLException, JsonProcessingException {
         List<SampleAggregated> aggregatedSamples = sampleService.getAggregatedSamples(request);
-        return new V0Response<>(new SampleAggregatedResponse(
+        V0Response<SampleAggregatedResponse> response = new V0Response<>(new SampleAggregatedResponse(
                 request.getFields(),
                 aggregatedSamples
         ));
+        return objectMapper.writeValueAsString(response);
     }
 
-    @GetMapping("/details")
-    public V0Response<SampleDetailResponse> getDetails(SampleDetailRequest request) throws SQLException {
+    @GetMapping(
+            value = "/details",
+            produces = "application/json"
+    )
+    public String getDetails(SampleDetailRequest request) throws SQLException, JsonProcessingException {
         List<SampleDetail> samples = sampleService.getDetailedSamples(request);
-        return new V0Response<>(new SampleDetailResponse(samples));
+        V0Response<SampleDetailResponse> response = new V0Response<>(new SampleDetailResponse(samples));
+        return objectMapper.writeValueAsString(response);
     }
 
-    @GetMapping("/aa-mutations")
-    public V0Response<SampleMutationsResponse> getAAMutations(SampleDetailRequest request) throws SQLException {
+    @GetMapping(
+            value = "/aa-mutations",
+            produces = "application/json"
+    )
+    public String getAAMutations(SampleDetailRequest request) throws SQLException, JsonProcessingException {
         SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.AMINO_ACID);
-        return new V0Response<>(mutationsResponse);
+        V0Response<SampleMutationsResponse> response = new V0Response<>(mutationsResponse);
+        return objectMapper.writeValueAsString(response);
     }
 
-    @GetMapping("/nuc-mutations")
-    public V0Response<SampleMutationsResponse> getNucMutations(SampleDetailRequest request) throws SQLException {
+    @GetMapping(
+            value = "/nuc-mutations",
+            produces = "application/json"
+    )
+    public String getNucMutations(SampleDetailRequest request) throws SQLException, JsonProcessingException {
         SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.NUCLEOTIDE);
-        return new V0Response<>(mutationsResponse);
+        V0Response<SampleMutationsResponse> response = new V0Response<>(mutationsResponse);
+        return objectMapper.writeValueAsString(response);
     }
 
     @GetMapping(

--- a/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
+++ b/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 
@@ -23,19 +24,19 @@ import java.util.function.Supplier;
 @RequestMapping("/v0/sample")
 public class SampleController {
 
-    private final CacheService cacheService;
+    private final Optional<CacheService> cacheServiceOpt;
     private final SampleService sampleService;
     private final DataVersionService dataVersionService;
     private final ObjectMapper objectMapper;
 
 
     public SampleController(
-            CacheService cacheService,
+            Optional<CacheService> cacheServiceOpt,
             SampleService sampleService,
             DataVersionService dataVersionService,
             ObjectMapper objectMapper
     ) {
-        this.cacheService = cacheService;
+        this.cacheServiceOpt = cacheServiceOpt;
         this.sampleService = sampleService;
         this.dataVersionService = dataVersionService;
         this.objectMapper = objectMapper;
@@ -127,6 +128,10 @@ public class SampleController {
 
 
     private String useCacheOrCompute(ApiCacheKey cacheKey, Supplier<String> compute) {
+        if (cacheServiceOpt.isEmpty()) {
+            return compute.get();
+        }
+        CacheService cacheService = cacheServiceOpt.get();
         String cached = cacheService.getCompressedString(cacheKey);
         if (cached != null) {
             System.out.println("Cache hit");

--- a/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
+++ b/server/src/main/java/ch/ethz/lapis/api/controller/v0/SampleController.java
@@ -1,6 +1,8 @@
 package ch.ethz.lapis.api.controller.v0;
 
+import ch.ethz.lapis.api.CacheService;
 import ch.ethz.lapis.api.SampleService;
+import ch.ethz.lapis.api.entity.ApiCacheKey;
 import ch.ethz.lapis.api.entity.SequenceType;
 import ch.ethz.lapis.api.entity.req.SampleAggregatedRequest;
 import ch.ethz.lapis.api.entity.req.SampleDetailRequest;
@@ -13,61 +15,92 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.function.Supplier;
+
 
 @RestController
 @RequestMapping("/v0/sample")
 public class SampleController {
 
+    private final CacheService cacheService;
     private final SampleService sampleService;
     private final ObjectMapper objectMapper;
 
-    public SampleController(SampleService sampleService, ObjectMapper objectMapper) {
+
+    public SampleController(
+            CacheService cacheService,
+            SampleService sampleService,
+            ObjectMapper objectMapper
+    ) {
+        this.cacheService = cacheService;
         this.sampleService = sampleService;
         this.objectMapper = objectMapper;
     }
+
 
     @GetMapping(
             value = "/aggregated",
             produces = "application/json"
     )
-    public String getAggregated(SampleAggregatedRequest request) throws SQLException, JsonProcessingException {
-        List<SampleAggregated> aggregatedSamples = sampleService.getAggregatedSamples(request);
-        V0Response<SampleAggregatedResponse> response = new V0Response<>(new SampleAggregatedResponse(
-                request.getFields(),
-                aggregatedSamples
-        ));
-        return objectMapper.writeValueAsString(response);
+    public String getAggregated(SampleAggregatedRequest request) {
+        ApiCacheKey cacheKey = new ApiCacheKey("/v0/sample/aggregated", request);
+        return useCacheOrCompute(cacheKey, () -> {
+            try {
+                List<SampleAggregated> aggregatedSamples = sampleService.getAggregatedSamples(request);
+                V0Response<SampleAggregatedResponse> response = new V0Response<>(new SampleAggregatedResponse(
+                        request.getFields(),
+                        aggregatedSamples
+                ));
+                return objectMapper.writeValueAsString(response);
+            } catch (SQLException | JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
-    @GetMapping(
-            value = "/details",
-            produces = "application/json"
-    )
-    public String getDetails(SampleDetailRequest request) throws SQLException, JsonProcessingException {
-        List<SampleDetail> samples = sampleService.getDetailedSamples(request);
-        V0Response<SampleDetailResponse> response = new V0Response<>(new SampleDetailResponse(samples));
-        return objectMapper.writeValueAsString(response);
+
+    @GetMapping( "/details")
+    public V0Response<SampleMutationsResponse> getDetails(SampleDetailRequest request) throws SQLException {
+        SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.AMINO_ACID);
+        return new V0Response<>(mutationsResponse);
     }
+
 
     @GetMapping(
             value = "/aa-mutations",
             produces = "application/json"
     )
-    public String getAAMutations(SampleDetailRequest request) throws SQLException, JsonProcessingException {
-        SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.AMINO_ACID);
-        V0Response<SampleMutationsResponse> response = new V0Response<>(mutationsResponse);
-        return objectMapper.writeValueAsString(response);
+    public String getAAMutations(SampleDetailRequest request) {
+        ApiCacheKey cacheKey = new ApiCacheKey("/v0/sample/aa-mutations", request);
+        return useCacheOrCompute(cacheKey, () -> {
+           try {
+               SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.AMINO_ACID);
+               V0Response<SampleMutationsResponse> response = new V0Response<>(mutationsResponse);
+               return objectMapper.writeValueAsString(response);
+           } catch (SQLException | JsonProcessingException e) {
+               throw new RuntimeException(e);
+           }
+        });
     }
+
 
     @GetMapping(
             value = "/nuc-mutations",
             produces = "application/json"
     )
-    public String getNucMutations(SampleDetailRequest request) throws SQLException, JsonProcessingException {
-        SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.NUCLEOTIDE);
-        V0Response<SampleMutationsResponse> response = new V0Response<>(mutationsResponse);
-        return objectMapper.writeValueAsString(response);
+    public String getNucMutations(SampleDetailRequest request) {
+        ApiCacheKey cacheKey = new ApiCacheKey("/v0/sample/nuc-mutations", request);
+        return useCacheOrCompute(cacheKey, () -> {
+           try {
+               SampleMutationsResponse mutationsResponse = sampleService.getMutations(request, SequenceType.NUCLEOTIDE);
+               V0Response<SampleMutationsResponse> response = new V0Response<>(mutationsResponse);
+               return objectMapper.writeValueAsString(response);
+           } catch (SQLException | JsonProcessingException e) {
+               throw new RuntimeException(e);
+           }
+        });
     }
+
 
     @GetMapping(
             value = "/fasta",
@@ -77,12 +110,26 @@ public class SampleController {
         return sampleService.getFasta(request, false);
     }
 
+
     @GetMapping(
             value = "/fasta-aligned",
             produces = "text/x-fasta"
     )
     public String getAlignedFasta(SampleDetailRequest request) throws SQLException {
         return sampleService.getFasta(request, true);
+    }
+
+
+    private String useCacheOrCompute(ApiCacheKey cacheKey, Supplier<String> compute) {
+        String cached = cacheService.getCompressedString(cacheKey);
+        if (cached != null) {
+            System.out.println("Cache hit");
+            return cached;
+        }
+        String response = compute.get();
+        System.out.println("Cache miss");
+        cacheService.setCompressedString(cacheKey, response);
+        return response;
     }
 
 }

--- a/server/src/main/java/ch/ethz/lapis/api/entity/AAMutation.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/AAMutation.java
@@ -10,6 +10,9 @@ public class AAMutation {
 
     private Character mutation;
 
+    public AAMutation() {
+    }
+
     public AAMutation(String gene, int position) {
         this.gene = gene;
         this.position = position;

--- a/server/src/main/java/ch/ethz/lapis/api/entity/ApiCacheKey.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/ApiCacheKey.java
@@ -1,0 +1,35 @@
+package ch.ethz.lapis.api.entity;
+
+
+public class ApiCacheKey {
+
+    private String endpointName;
+
+    private Object requestObject;
+
+    public ApiCacheKey() {
+    }
+
+    public ApiCacheKey(String endpointName, Object requestObject) {
+        this.endpointName = endpointName;
+        this.requestObject = requestObject;
+    }
+
+    public String getEndpointName() {
+        return endpointName;
+    }
+
+    public ApiCacheKey setEndpointName(String endpointName) {
+        this.endpointName = endpointName;
+        return this;
+    }
+
+    public Object getRequestObject() {
+        return requestObject;
+    }
+
+    public ApiCacheKey setRequestObject(Object requestObject) {
+        this.requestObject = requestObject;
+        return this;
+    }
+}

--- a/server/src/main/java/ch/ethz/lapis/api/entity/NucMutation.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/NucMutation.java
@@ -8,6 +8,9 @@ public class NucMutation {
 
     private Character mutation;
 
+    public NucMutation() {
+    }
+
     public NucMutation(int position) {
         this.position = position;
     }

--- a/server/src/main/java/ch/ethz/lapis/api/entity/res/Information.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/res/Information.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 public class Information {
 
     private int apiVersion = 0;
+    private long dataVersion = -1;
     private LocalDate deprecationDate = null;
     private String deprecationInfo = null;
 
@@ -14,6 +15,15 @@ public class Information {
 
     public Information setApiVersion(int apiVersion) {
         this.apiVersion = apiVersion;
+        return this;
+    }
+
+    public long getDataVersion() {
+        return dataVersion;
+    }
+
+    public Information setDataVersion(long dataVersion) {
+        this.dataVersion = dataVersion;
         return this;
     }
 

--- a/server/src/main/java/ch/ethz/lapis/api/entity/res/V0Response.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/res/V0Response.java
@@ -18,8 +18,9 @@ public class V0Response<Payload> {
     public V0Response() {
     }
 
-    public V0Response(Payload payload) {
+    public V0Response(Payload payload, long dataVersion) {
         this.payload = payload;
+        this.info.setDataVersion(dataVersion);
     }
 
     public Payload getPayload() {


### PR DESCRIPTION
This PR introduces a caching service. Responses of the endpoints `aggregated`, `aa-mutations` and `nuc-mutations` can be cached. The cache is stored in Redis.