### PR TITLE
Implement an in-memory query engine and use it for /aggregated

### DIFF
--- a/server/src/main/java/ch/ethz/lapis/api/DataVersionService.java
+++ b/server/src/main/java/ch/ethz/lapis/api/DataVersionService.java
@@ -2,6 +2,7 @@ package ch.ethz.lapis.api;
 
 import ch.ethz.lapis.LapisMain;
 import ch.ethz.lapis.api.query.DataStore;
+import ch.ethz.lapis.api.query2.Database;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,13 @@ public class DataVersionService {
                     if (newVersion != version) {
                         // Update the cache
                         System.out.println("New data version: " + version + " -> " + newVersion);
+                        if (version == -1) {
+                            // Initial loading. Using getOrLoadInstance() prevents the data to be loaded in parallel,
+                            // e.g., by SampleController.
+                            Database.getOrLoadInstance(dbPool);
+                        } else {
+                            Database.updateInstance(dbPool);
+                        }
                         version = newVersion;
                         if (cacheServiceOpt.isPresent()) {
                             cacheServiceOpt.get().updateCacheIfOutdated(version);

--- a/server/src/main/java/ch/ethz/lapis/api/controller/v1/SampleController.java
+++ b/server/src/main/java/ch/ethz/lapis/api/controller/v1/SampleController.java
@@ -75,7 +75,8 @@ public class SampleController {
         ApiCacheKey cacheKey = new ApiCacheKey(CacheService.SupportedEndpoints.SAMPLE_AGGREGATED, request);
         String body = useCacheOrCompute(cacheKey, () -> {
             try {
-                List<SampleAggregated> aggregatedSamples = sampleService.getAggregatedSamples(request, stopWatch);
+                stopWatch.round("Query data");
+                List<SampleAggregated> aggregatedSamples = sampleService.getAggregatedSamples(request);
                 stopWatch.round("Result formatting");
                 V1Response<SampleAggregatedResponse> response = new V1Response<>(new SampleAggregatedResponse(
                     request.getFields(),

--- a/server/src/main/java/ch/ethz/lapis/api/entity/AAMutation.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/AAMutation.java
@@ -2,6 +2,7 @@ package ch.ethz.lapis.api.entity;
 
 import ch.ethz.lapis.api.query.DataStore;
 import ch.ethz.lapis.api.query.VariantQueryExpr;
+import ch.ethz.lapis.api.query2.Database;
 import ch.ethz.lapis.util.ReferenceGenomeData;
 import ch.ethz.lapis.util.Utils;
 
@@ -85,6 +86,16 @@ public class AAMutation implements VariantQueryExpr {
     @Override
     public boolean[] evaluate(DataStore dataStore) {
         char[] data = dataStore.getAAArray(gene, position);
+        boolean[] result = new boolean[data.length];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = isMatchingMutation(data[i], this);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        char[] data = database.getAAArray(gene, position);
         boolean[] result = new boolean[data.length];
         for (int i = 0; i < result.length; i++) {
             result[i] = isMatchingMutation(data[i], this);

--- a/server/src/main/java/ch/ethz/lapis/api/entity/NucMutation.java
+++ b/server/src/main/java/ch/ethz/lapis/api/entity/NucMutation.java
@@ -2,6 +2,7 @@ package ch.ethz.lapis.api.entity;
 
 import ch.ethz.lapis.api.query.DataStore;
 import ch.ethz.lapis.api.query.VariantQueryExpr;
+import ch.ethz.lapis.api.query2.Database;
 import ch.ethz.lapis.util.ReferenceGenomeData;
 import ch.ethz.lapis.util.Utils;
 
@@ -69,6 +70,16 @@ public class NucMutation implements VariantQueryExpr {
     @Override
     public boolean[] evaluate(DataStore dataStore) {
         char[] data = dataStore.getNucArray(position);
+        boolean[] result = new boolean[data.length];
+        for (int i = 0; i < result.length; i++) {
+            result[i] = isMatchingMutation(data[i], this);
+        }
+        return result;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        char[] data = database.getNucArray(position);
         boolean[] result = new boolean[data.length];
         for (int i = 0; i < result.length; i++) {
             result[i] = isMatchingMutation(data[i], this);

--- a/server/src/main/java/ch/ethz/lapis/api/exception/OutdatedDataVersionException.java
+++ b/server/src/main/java/ch/ethz/lapis/api/exception/OutdatedDataVersionException.java
@@ -8,8 +8,11 @@ import java.util.List;
 
 public class OutdatedDataVersionException extends BaseApiException {
 
-    private final long requestedDataVersion;
-    private final long currentDataVersion;
+    private long requestedDataVersion = -1;
+    private long currentDataVersion = -1;
+
+    public OutdatedDataVersionException() {
+    }
 
     public OutdatedDataVersionException(long requestedDataVersion, long currentDataVersion) {
         this.requestedDataVersion = requestedDataVersion;
@@ -23,10 +26,16 @@ public class OutdatedDataVersionException extends BaseApiException {
 
     @Override
     public List<ErrorEntry> getErrorEntries() {
-        return List.of(new ErrorEntry(
-            "The requested data version " + requestedDataVersion + " does not exist anymore. The current data " +
-                "version is " + currentDataVersion + "."
-        ));
+        if (requestedDataVersion != -1) {
+            return List.of(new ErrorEntry(
+                "The requested data version " + requestedDataVersion + " does not exist anymore. The current data " +
+                    "version is " + currentDataVersion + "."
+            ));
+        } else {
+            return List.of(new ErrorEntry(
+                "The requested data version does not exist anymore. Please wait a moment and reload."
+            ));
+        }
     }
 
 }

--- a/server/src/main/java/ch/ethz/lapis/api/query/BiOp.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query/BiOp.java
@@ -1,5 +1,7 @@
 package ch.ethz.lapis.api.query;
 
+import ch.ethz.lapis.api.query2.Database;
+
 public class BiOp implements VariantQueryExpr {
 
     public enum OpType {
@@ -30,6 +32,23 @@ public class BiOp implements VariantQueryExpr {
     public boolean[] evaluate(DataStore dataStore) {
         boolean[] leftEvaluated = left.evaluate(dataStore);
         boolean[] rightEvaluated = right.evaluate(dataStore);
+        boolean[] result = new boolean[leftEvaluated.length];
+        if (opType == OpType.AND) {
+            for (int i = 0; i < result.length; i++) {
+                result[i] = leftEvaluated[i] && rightEvaluated[i];
+            }
+        } else if (opType == OpType.OR) {
+            for (int i = 0; i < result.length; i++) {
+                result[i] = leftEvaluated[i] || rightEvaluated[i];
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        boolean[] leftEvaluated = left.evaluate2(database);
+        boolean[] rightEvaluated = right.evaluate2(database);
         boolean[] result = new boolean[leftEvaluated.length];
         if (opType == OpType.AND) {
             for (int i = 0; i < result.length; i++) {

--- a/server/src/main/java/ch/ethz/lapis/api/query/GisaidClade.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query/GisaidClade.java
@@ -1,5 +1,8 @@
 package ch.ethz.lapis.api.query;
 
+import ch.ethz.lapis.api.query2.Database;
+import ch.ethz.lapis.api.query2.StringValue;
+
 public class GisaidClade implements VariantQueryExpr {
 
     private final String clade;
@@ -21,5 +24,10 @@ public class GisaidClade implements VariantQueryExpr {
             result[i] = clade.equals(data[i]);
         }
         return result;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        return new StringValue(clade, Database.Columns.GISAID_CLADE, false).evaluate2(database);
     }
 }

--- a/server/src/main/java/ch/ethz/lapis/api/query/NextstrainClade.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query/NextstrainClade.java
@@ -1,5 +1,8 @@
 package ch.ethz.lapis.api.query;
 
+import ch.ethz.lapis.api.query2.Database;
+import ch.ethz.lapis.api.query2.StringValue;
+
 public class NextstrainClade implements VariantQueryExpr {
 
     private final String clade;
@@ -21,5 +24,10 @@ public class NextstrainClade implements VariantQueryExpr {
             result[i] = clade.equals(data[i]);
         }
         return result;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        return new StringValue(clade, Database.Columns.NEXTSTRAIN_CLADE, false).evaluate2(database);
     }
 }

--- a/server/src/main/java/ch/ethz/lapis/api/query/PangoQuery.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query/PangoQuery.java
@@ -1,5 +1,6 @@
 package ch.ethz.lapis.api.query;
 
+import ch.ethz.lapis.api.query2.Database;
 import ch.ethz.lapis.util.PangoLineageQueryConverter;
 
 public class PangoQuery implements VariantQueryExpr {
@@ -39,6 +40,34 @@ public class PangoQuery implements VariantQueryExpr {
         PangoLineageQueryConverter.PangoLineageQueryMatch match = queryConverter.convert(pangoLineage);
 
         String[] data = dataStore.getPangoLineageArray();
+        boolean[] result = new boolean[data.length];
+
+        for (int i = 0; i < result.length; i++) {
+            boolean r = false;
+            String d = data[i];
+            if (d != null) {
+                for (String s : match.getExact()) {
+                    r = r || d.equals(s);
+                }
+                for (String s : match.getPrefix()) {
+                    r = r || d.startsWith(s);
+                }
+            }
+            result[i] = r;
+        }
+        return result;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        String pangoLineage = this.pangoLineage.toUpperCase();
+        if (includeSubLineage) {
+            pangoLineage += "*";
+        }
+        PangoLineageQueryConverter queryConverter = database.getPangoLineageQueryConverter();
+        PangoLineageQueryConverter.PangoLineageQueryMatch match = queryConverter.convert(pangoLineage);
+
+        String[] data = database.getStringColumn(Database.Columns.PANGO_LINEAGE);
         boolean[] result = new boolean[data.length];
 
         for (int i = 0; i < result.length; i++) {

--- a/server/src/main/java/ch/ethz/lapis/api/query/Single.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query/Single.java
@@ -1,5 +1,7 @@
 package ch.ethz.lapis.api.query;
 
+import ch.ethz.lapis.api.query2.Database;
+
 public class Single implements VariantQueryExpr {
     private VariantQueryExpr value;
 
@@ -13,7 +15,13 @@ public class Single implements VariantQueryExpr {
         return value.evaluate(dataStore);
     }
 
+    @Override
+    public boolean[] evaluate2(Database database) {
+        return value.evaluate2(database);
+    }
+
     public VariantQueryExpr getValue() {
         return value;
     }
+
 }

--- a/server/src/main/java/ch/ethz/lapis/api/query/VariantQueryExpr.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query/VariantQueryExpr.java
@@ -1,8 +1,9 @@
 package ch.ethz.lapis.api.query;
 
 import ch.ethz.lapis.api.exception.MalformedVariantQueryException;
+import ch.ethz.lapis.api.query2.QueryExpr;
 
-public interface VariantQueryExpr {
+public interface VariantQueryExpr extends QueryExpr {
 
     default void putValue(VariantQueryExpr value) {
         throw new MalformedVariantQueryException();

--- a/server/src/main/java/ch/ethz/lapis/api/query2/Database.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query2/Database.java
@@ -1,0 +1,327 @@
+package ch.ethz.lapis.api.query2;
+
+import ch.ethz.lapis.api.exception.OutdatedDataVersionException;
+import ch.ethz.lapis.util.PangoLineageAlias;
+import ch.ethz.lapis.util.PangoLineageQueryConverter;
+import ch.ethz.lapis.util.SeqCompressor;
+import ch.ethz.lapis.util.ZstdSeqCompressor;
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import java.sql.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Database {
+
+    public static class Columns {
+        public static final String GENBANK_ACCESSION = "genbank_accession"; // String
+        public static final String SRA_ACCESSION  = "sra_accession"; // String
+        public static final String GISAID_EPI_ISL  = "gisaid_epi_isl"; // String
+        public static final String STRAIN  = "strain"; // String
+        public static final String DATE = "date"; // Date
+        public static final String DATE_SUBMITTED = "date_submitted"; // Date
+        public static final String REGION = "region"; // String
+        public static final String COUNTRY = "country"; // String
+        public static final String DIVISION = "division"; // String
+        public static final String LOCATION = "location"; // String
+        public static final String REGION_EXPOSURE = "region_exposure"; // String
+        public static final String COUNTRY_EXPOSURE = "country_exposure"; // String
+        public static final String DIVISION_EXPOSURE = "division_exposure"; // String
+        public static final String HOST = "host"; // String
+        public static final String AGE = "age"; // Integer
+        public static final String SEX = "sex"; // String
+        public static final String HOSPITALIZED = "hospitalized"; // Boolean
+        public static final String DIED = "died"; // Boolean
+        public static final String FULLY_VACCINATED = "fully_vaccinated"; // Boolean
+        public static final String SAMPLING_STRATEGY = "sampling_strategy"; // String
+        public static final String PANGO_LINEAGE = "pango_lineage"; // String
+        public static final String NEXTSTRAIN_CLADE = "nextstrain_clade"; // String
+        public static final String GISAID_CLADE = "gisaid_clade"; // String
+        public static final String ORIGINATING_LAB = "originating_lab"; // String
+        public static final String SUBMITTING_LAB = "submitting_lab"; // String
+    }
+
+    public static final String[] ALL_COLUMNS = new String[] {
+        Columns.GENBANK_ACCESSION, Columns.SRA_ACCESSION, Columns.GISAID_EPI_ISL, Columns.STRAIN,
+        Columns.DATE, Columns.DATE_SUBMITTED, Columns.REGION, Columns.COUNTRY, Columns.DIVISION,
+        Columns.LOCATION, Columns.REGION_EXPOSURE, Columns.COUNTRY_EXPOSURE, Columns.DIVISION_EXPOSURE,
+        Columns.HOST, Columns.AGE, Columns.SEX, Columns.HOSPITALIZED, Columns.DIED, Columns.FULLY_VACCINATED,
+        Columns.SAMPLING_STRATEGY, Columns.PANGO_LINEAGE, Columns.NEXTSTRAIN_CLADE, Columns.GISAID_CLADE,
+        Columns.ORIGINATING_LAB, Columns.SUBMITTING_LAB
+    };
+    public static final String[] STRING_COLUMNS = new String[] {
+        Columns.GENBANK_ACCESSION, Columns.SRA_ACCESSION, Columns.GISAID_EPI_ISL, Columns.STRAIN,
+        Columns.REGION, Columns.COUNTRY, Columns.DIVISION, Columns.LOCATION, Columns.REGION_EXPOSURE,
+        Columns.COUNTRY_EXPOSURE, Columns.DIVISION_EXPOSURE, Columns.HOST, Columns.SEX,
+        Columns.SAMPLING_STRATEGY, Columns.PANGO_LINEAGE, Columns.NEXTSTRAIN_CLADE, Columns.GISAID_CLADE,
+        Columns.ORIGINATING_LAB, Columns.SUBMITTING_LAB
+    };
+    public static final String[] DATE_COLUMNS = new String[] {
+        Columns.DATE, Columns.DATE_SUBMITTED
+    };
+    public static final String[] INTEGER_COLUMNS = new String[] {
+        Columns.AGE
+    };
+    public static final String[] BOOLEAN_COLUMNS = new String[] {
+        Columns.HOSPITALIZED, Columns.DIED, Columns.FULLY_VACCINATED
+    };
+
+    private static Database instance;
+
+    private static final SeqCompressor columnarCompressor = new ZstdSeqCompressor(ZstdSeqCompressor.DICT.NONE);
+    private final long dataVersion;
+    private final int size;
+    private final PangoLineageQueryConverter pangoLineageQueryConverter;
+    private final ComboPooledDataSource databasePool;
+    private final Map<String, String[]> stringColumns = new HashMap<>();
+    private final Map<String, Integer[]> integerColumns = new HashMap<>();
+    private final Map<String, Boolean[]> booleanColumns = new HashMap<>();
+
+    private Database(
+        long dataVersion,
+        int size,
+        ComboPooledDataSource databasePool,
+        PangoLineageQueryConverter pangoLineageQueryConverter
+    ) {
+        this.dataVersion = dataVersion;
+        this.size = size;
+        this.databasePool = databasePool;
+        this.pangoLineageQueryConverter = pangoLineageQueryConverter;
+    }
+
+
+    public long getDataVersion() {
+        return dataVersion;
+    }
+
+
+    public int size() {
+        return size;
+    }
+
+    public PangoLineageQueryConverter getPangoLineageQueryConverter() {
+        return pangoLineageQueryConverter;
+    }
+
+
+    public String[] getStringColumn(String columnName) {
+        return stringColumns.get(columnName);
+    }
+
+
+    public Integer[] getIntColumn(String columnName) {
+        return integerColumns.get(columnName);
+    }
+
+
+    public Boolean[] getBoolColumn(String columnName) {
+        return booleanColumns.get(columnName);
+    }
+
+
+    public Object[] getColumn(String columnName) {
+        if (stringColumns.containsKey(columnName)) {
+            return stringColumns.get(columnName);
+        }
+        if (integerColumns.containsKey(columnName)) {
+            return integerColumns.get(columnName);
+        }
+        if (booleanColumns.containsKey(columnName)) {
+            return booleanColumns.get(columnName);
+        }
+        return null;
+    }
+
+    private static List<PangoLineageAlias> getPangolinLineageAliases(Connection conn) throws SQLException {
+        String sql = """
+            select
+              alias,
+              full_name
+            from pangolin_lineage_alias;
+        """;
+        try (Statement statement = conn.createStatement()) {
+            try (ResultSet rs = statement.executeQuery(sql)) {
+                List<PangoLineageAlias> aliases = new ArrayList<>();
+                while (rs.next()) {
+                    aliases.add(new PangoLineageAlias(
+                        rs.getString("alias"),
+                        rs.getString("full_name")
+                    ));
+                }
+                return aliases;
+            }
+        }
+    }
+
+
+    public char[] getNucArray(int position) {
+        String sql = """
+            select data_compressed
+            from y_main_sequence_columnar
+            where position = ?;
+        """;
+        try (Connection conn = databasePool.getConnection()) {
+            try (PreparedStatement statement = conn.prepareStatement(sql)) {
+                statement.setInt(1, position);
+                try (ResultSet rs = statement.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    byte[] compressed = rs.getBytes("data_compressed");
+                    char[] result = columnarCompressor.decompress(compressed).toCharArray();
+                    if (result.length != size) {
+                        // New data arrived. The available sequence data does not match the current database anymore.
+                        throw new OutdatedDataVersionException();
+                    }
+                    return result;
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public char[] getAAArray(String gene, int position) {
+        String sql = """
+            select data_compressed
+            from y_main_aa_sequence_columnar
+            where lower(gene) = lower(?) and position = ?;
+        """;
+        try (Connection conn = databasePool.getConnection()) {
+            try (PreparedStatement statement = conn.prepareStatement(sql)) {
+                statement.setString(1, gene);
+                statement.setInt(2, position);
+                try (ResultSet rs = statement.executeQuery()) {
+                    if (!rs.next()) {
+                        return null;
+                    }
+                    byte[] compressed = rs.getBytes("data_compressed");
+                    char[] result = columnarCompressor.decompress(compressed).toCharArray();
+                    if (result.length != size) {
+                        // New data arrived. The available sequence data does not match the current database anymore.
+                        throw new OutdatedDataVersionException();
+                    }
+                    return result;
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void updateInstance(ComboPooledDataSource databasePool) {
+        try {
+            instance = loadDatabase(databasePool);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static synchronized Database getOrLoadInstance(ComboPooledDataSource databasePool) {
+        if (instance == null) {
+            updateInstance(databasePool);
+        }
+        return instance;
+    }
+
+    private static Database loadDatabase(ComboPooledDataSource databasePool) throws SQLException {
+        try (Connection conn = databasePool.getConnection()) {
+            conn.setAutoCommit(false);
+            String dataVersionSql = """
+                select timestamp
+                from data_version
+                where dataset = 'merged';
+                """;
+            String lengthSql = """
+                select count(*) as count
+                from y_main_metadata
+                """;
+            String metadataSql = """
+                select *
+                from y_main_metadata
+                order by id;
+                """;
+            Database database;
+            try (Statement statement = conn.createStatement()) {
+                // Fetch data version
+                long dataVersion;
+                try (ResultSet rs = statement.executeQuery(dataVersionSql)) {
+                    if (!rs.next()) {
+                        throw new RuntimeException("The data version cannot be found in the database.");
+                    }
+                    dataVersion = rs.getLong("timestamp");
+
+                }
+                // Fetch number of rows
+                int numberRows;
+                try (ResultSet rs = statement.executeQuery(lengthSql)) {
+                    rs.next();
+                    numberRows = rs.getInt("count");
+
+                }
+                // Fetch pango lineage aliases
+                List<PangoLineageAlias> aliases = getPangolinLineageAliases(conn);
+                PangoLineageQueryConverter pangoLineageQueryConverter = new PangoLineageQueryConverter(aliases);
+                // Create database object
+                database = new Database(
+                    dataVersion,
+                    numberRows,
+                    databasePool,
+                    pangoLineageQueryConverter
+                );
+                // Fetch metadata
+                for (String stringColumn : STRING_COLUMNS) {
+                    database.stringColumns.put(stringColumn, new String[numberRows]);
+                }
+                for (String integerColumn : INTEGER_COLUMNS) {
+                    database.integerColumns.put(integerColumn, new Integer[numberRows]);
+                }
+                for (String dateColumn : DATE_COLUMNS) {
+                    database.integerColumns.put(dateColumn, new Integer[numberRows]);
+                }
+                for (String booleanColumn : BOOLEAN_COLUMNS) {
+                    database.booleanColumns.put(booleanColumn, new Boolean[numberRows]);
+                }
+                statement.setFetchSize(20000);
+                try (ResultSet rs = statement.executeQuery(metadataSql)) {
+                    int i = 0;
+                    while (rs.next()) {
+                        if (i % 50000 == 0) {
+                            System.out.println("Loading data to in-memory database: " + i + "/" + numberRows);
+                        }
+                        for (String stringColumn : STRING_COLUMNS) {
+                            String s = rs.getString(stringColumn);
+                            database.stringColumns.get(stringColumn)[i] = s != null ? s.intern() : null;
+                        }
+                        for (String integerColumn : INTEGER_COLUMNS) {
+                            database.integerColumns.get(integerColumn)[i] = rs.getObject(integerColumn, Integer.class);
+                        }
+                        for (String dateColumn : DATE_COLUMNS) {
+                            Date dateObj = rs.getDate(dateColumn);
+                            Integer dateInt = dateObj != null ? dateToInt(dateObj.toLocalDate()) : null;
+                            database.integerColumns.get(dateColumn)[i] = dateInt;
+                        }
+                        for (String booleanColumn : BOOLEAN_COLUMNS) {
+                            database.booleanColumns.get(booleanColumn)[i] = rs.getObject(booleanColumn, Boolean.class);
+                        }
+                        ++i;
+                    }
+                }
+            }
+            conn.setAutoCommit(true);
+            return database;
+        }
+    }
+
+    public static Integer dateToInt(LocalDate date) {
+        return date != null ? (int) date.toEpochDay() : null;
+    }
+
+    public static LocalDate intToDate(Integer dateInt) {
+        return dateInt != null ? LocalDate.ofEpochDay(dateInt) : null;
+    }
+}

--- a/server/src/main/java/ch/ethz/lapis/api/query2/QueryEngine.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query2/QueryEngine.java
@@ -1,0 +1,258 @@
+package ch.ethz.lapis.api.query2;
+
+import ch.ethz.lapis.api.VariantQueryListener;
+import ch.ethz.lapis.api.entity.AggregationField;
+import ch.ethz.lapis.api.entity.req.SampleAggregatedRequest;
+import ch.ethz.lapis.api.entity.res.SampleAggregated;
+import ch.ethz.lapis.api.parser.VariantQueryLexer;
+import ch.ethz.lapis.api.parser.VariantQueryParser;
+import ch.ethz.lapis.api.query.*;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static ch.ethz.lapis.api.query2.Database.Columns.*;
+
+public class QueryEngine {
+
+    public List<SampleAggregated> aggregate(Database database, SampleAggregatedRequest request) {
+        // Filter variant
+        var nucMutations = request.getNucMutations();
+        var useNucMutations = nucMutations != null && !nucMutations.isEmpty();
+        var aaMutations = request.getAaMutations();
+        var useAaMutations = aaMutations != null && !aaMutations.isEmpty();
+        var pangoLineage = request.getPangoLineage();
+        var usePangoLineage = pangoLineage != null;
+        var gisaidClade = request.getGisaidClade();
+        var useGisaidClade = gisaidClade != null;
+        var nextstrainClade = request.getNextstrainClade();
+        var useNextstrainClade = nextstrainClade != null;
+        var variantQuery = request.getVariantQuery();
+        var useVariantQuery = variantQuery != null;
+
+        boolean useOtherVariantSpecifying = useNucMutations || useAaMutations || usePangoLineage || useGisaidClade
+            || useNextstrainClade;
+        if (useVariantQuery && useOtherVariantSpecifying) {
+            throw new RuntimeException("It is not allowed to use variantQuery and another variant-specifying " +
+                "field at the same time.");
+        }
+
+        VariantQueryExpr variantQueryExpr = null;
+        if (useVariantQuery) {
+            variantQueryExpr = parseVariantQueryExpr(variantQuery);
+        } else if (useOtherVariantSpecifying) {
+            List<VariantQueryExpr> components = new ArrayList<>();
+            if (usePangoLineage) {
+                PangoQuery pq;
+                if (pangoLineage.endsWith("*")) {
+                    pq = new PangoQuery(pangoLineage.substring(0, pangoLineage.length() - 1), true);
+                } else {
+                    pq = new PangoQuery(pangoLineage, false);
+                }
+                components.add(pq);
+            }
+            if (useNextstrainClade) {
+                components.add(new NextstrainClade(nextstrainClade));
+            }
+            if (useGisaidClade) {
+                components.add(new GisaidClade(gisaidClade));
+            }
+            if (useAaMutations) {
+                components.addAll(aaMutations);
+            }
+            if (useNucMutations) {
+                components.addAll(nucMutations);
+            }
+            variantQueryExpr = components.get(0);
+            for (int i = 1; i < components.size(); i++) {
+                BiOp conjunction = new BiOp(BiOp.OpType.AND);
+                conjunction.putValue(variantQueryExpr);
+                conjunction.putValue(components.get(i));
+                variantQueryExpr = conjunction;
+            }
+        }
+
+        int numberRows = database.size();
+        boolean[] matched;
+        if (variantQueryExpr != null) {
+            matched = variantQueryExpr.evaluate2(database);
+        } else {
+            matched = new boolean[numberRows];
+            Arrays.fill(matched, true);
+        }
+
+        // Filter metadata
+        between(matched, database.getIntColumn(DATE), request.getDateFrom(), request.getDateTo());
+        between(matched, database.getIntColumn(DATE_SUBMITTED),
+            request.getDateSubmittedFrom(), request.getDateSubmittedTo());
+        eq(matched, database.getStringColumn(REGION), request.getRegion(), true);
+        eq(matched, database.getStringColumn(COUNTRY), request.getCountry(), true);
+        eq(matched, database.getStringColumn(DIVISION), request.getDivision(), true);
+        eq(matched, database.getStringColumn(LOCATION), request.getLocation(), true);
+        eq(matched, database.getStringColumn(REGION_EXPOSURE), request.getRegionExposure(), true);
+        eq(matched, database.getStringColumn(COUNTRY_EXPOSURE), request.getCountryExposure(), true);
+        eq(matched, database.getStringColumn(DIVISION_EXPOSURE), request.getDivisionExposure(), true);
+        between(matched, database.getIntColumn(AGE), request.getAgeFrom(), request.getAgeTo());
+        eq(matched, database.getStringColumn(SEX), request.getSex(), true);
+        eq(matched, database.getBoolColumn(HOSPITALIZED), request.getHospitalized());
+        eq(matched, database.getBoolColumn(DIED), request.getDied());
+        eq(matched, database.getBoolColumn(FULLY_VACCINATED), request.getFullyVaccinated());
+        eq(matched, database.getStringColumn(HOST), request.getHost(), true);
+        eq(matched, database.getStringColumn(SAMPLING_STRATEGY), request.getSamplingStrategy(), true);
+        eq(matched, database.getStringColumn(SUBMITTING_LAB), request.getSubmittingLab(), true);
+        eq(matched, database.getStringColumn(ORIGINATING_LAB), request.getOriginatingLab(), true);
+
+        // Group by
+        List<SampleAggregated> result = new ArrayList<>();
+        List<AggregationField> fields = request.getFields();
+        if (fields.isEmpty()) {
+            int count = 0;
+            for (int i = 0; i < numberRows; i++) {
+                if (matched[i]) {
+                    ++count;
+                }
+            }
+            result.add(new SampleAggregated().setCount(count));
+        } else {
+            Map<List<Object>, int[]> counts = new HashMap<>();
+            for (int i = 0; i < numberRows; i++) {
+                if (matched[i]) {
+                    int finalI = i;
+                    List<Object> key = fields.stream()
+                        .map(f -> database.getColumn(aggregationFieldToColumnName(f))[finalI])
+                        .collect(Collectors.toList());
+                    counts.compute(key, (k, v) -> v == null ?
+                        new int[] { 0 } : v)[0]++;
+                }
+            }
+            for (Map.Entry<List<Object>, int[]> entry : counts.entrySet()) {
+                SampleAggregated sampleAggregated = new SampleAggregated().setCount(entry.getValue()[0]);
+                List<Object> key = entry.getKey();
+                for (int i = 0; i < fields.size(); i++) {
+                    switch (fields.get(i)) {
+                        case DATE -> sampleAggregated.setDate(Database.intToDate((Integer) key.get(i)));
+                        case DATESUBMITTED -> sampleAggregated
+                            .setDateSubmitted(Database.intToDate((Integer) key.get(i)));
+                        case REGION -> sampleAggregated.setRegion((String) key.get(i));
+                        case COUNTRY -> sampleAggregated.setCountry((String) key.get(i));
+                        case DIVISION -> sampleAggregated.setDivision((String) key.get(i));
+                        case LOCATION -> sampleAggregated.setLocation((String) key.get(i));
+                        case REGIONEXPOSURE -> sampleAggregated.setRegionExposure((String) key.get(i));
+                        case COUNTRYEXPOSURE -> sampleAggregated.setCountryExposure((String) key.get(i));
+                        case DIVISIONEXPOSURE -> sampleAggregated.setDivisionExposure((String) key.get(i));
+                        case AGE -> sampleAggregated.setAge((Integer) key.get(i));
+                        case SEX -> sampleAggregated.setSex((String) key.get(i));
+                        case HOSPITALIZED -> sampleAggregated.setHospitalized((Boolean) key.get(i));
+                        case DIED -> sampleAggregated.setDied((Boolean) key.get(i));
+                        case FULLYVACCINATED -> sampleAggregated.setFullyVaccinated((Boolean) key.get(i));
+                        case HOST -> sampleAggregated.setHost((String) key.get(i));
+                        case SAMPLINGSTRATEGY -> sampleAggregated.setSamplingStrategy((String) key.get(i));
+                        case PANGOLINEAGE -> sampleAggregated.setPangoLineage((String) key.get(i));
+                        case NEXTSTRAINCLADE -> sampleAggregated.setNextstrainClade((String) key.get(i));
+                        case GISAIDCLADE -> sampleAggregated.setGisaidCloade((String) key.get(i));
+                        case SUBMITTINGLAB -> sampleAggregated.setSubmittingLab((String) key.get(i));
+                        case ORIGINATINGLAB -> sampleAggregated.setOriginatingLab((String) key.get(i));
+                    }
+                }
+                result.add(sampleAggregated);
+            }
+        }
+
+        return result;
+    }
+
+    private void eq(boolean[] matched, String[] data, String value, boolean caseSensitive) {
+        if (value == null) {
+            return;
+        }
+        if (caseSensitive) {
+            for (int i = 0; i < matched.length; i++) {
+                matched[i] = matched[i] && value.equals(data[i]);
+            }
+        } else {
+            for (int i = 0; i < matched.length; i++) {
+                matched[i] = matched[i] && value.equalsIgnoreCase(data[i]);
+            }
+        }
+    }
+
+    private void eq(boolean[] matched, Boolean[] data, Boolean value) {
+        if (value == null) {
+            return;
+        }
+        for (int i = 0; i < matched.length; i++) {
+            matched[i] = matched[i] && data[i] != null && value == data[i];
+        }
+    }
+
+    private void between(boolean[] matched, Integer[] data, Integer from, Integer to) {
+        if (from == null && to == null) {
+            return;
+        }
+        if (from != null && to != null) {
+            for (int i = 0; i < matched.length; i++) {
+                matched[i] = matched[i] && data[i] != null && data[i] >= from && data[i] <= to;
+            }
+        } else if (from != null) {
+            for (int i = 0; i < matched.length; i++) {
+                matched[i] = matched[i] && data[i] != null && data[i] >= from;
+            }
+        } else {
+            for (int i = 0; i < matched.length; i++) {
+                matched[i] = matched[i] && data[i] != null && data[i] <= to;
+            }
+        }
+    }
+
+    private void between(boolean[] matched, Integer[] data, LocalDate dateFrom, LocalDate dateTo) {
+        Integer dateFromInt = Database.dateToInt(dateFrom);
+        Integer dateToInt = Database.dateToInt(dateTo);
+        between(matched, data, dateFromInt, dateToInt);
+    }
+
+    private VariantQueryExpr parseVariantQueryExpr(String variantQuery) {
+        VariantQueryLexer lexer = new VariantQueryLexer(CharStreams.fromString(variantQuery.toUpperCase()));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        VariantQueryParser parser = new VariantQueryParser(tokens);
+        parser.removeErrorListeners();
+        parser.addErrorListener(ThrowingErrorListener.INSTANCE);
+        ParseTree tree = parser.start();
+        ParseTreeWalker walker = new ParseTreeWalker();
+        VariantQueryListener listener = new VariantQueryListener();
+        walker.walk(listener, tree);
+        return listener.getExpr();
+    }
+
+    private String aggregationFieldToColumnName(AggregationField field) {
+        return switch (field) {
+            case DATE -> DATE;
+            case DATESUBMITTED -> DATE_SUBMITTED;
+            case REGION -> REGION;
+            case COUNTRY -> COUNTRY;
+            case DIVISION -> DIVISION;
+            case LOCATION -> LOCATION;
+            case REGIONEXPOSURE -> REGION_EXPOSURE;
+            case COUNTRYEXPOSURE -> COUNTRY_EXPOSURE;
+            case DIVISIONEXPOSURE -> DIVISION_EXPOSURE;
+            case AGE -> AGE;
+            case SEX -> SEX;
+            case HOSPITALIZED -> HOSPITALIZED;
+            case DIED -> DIED;
+            case FULLYVACCINATED -> FULLY_VACCINATED;
+            case HOST -> HOST;
+            case SAMPLINGSTRATEGY -> SAMPLING_STRATEGY;
+            case PANGOLINEAGE -> PANGO_LINEAGE;
+            case NEXTSTRAINCLADE -> NEXTSTRAIN_CLADE;
+            case GISAIDCLADE -> GISAID_CLADE;
+            case SUBMITTINGLAB -> SUBMITTING_LAB;
+            case ORIGINATINGLAB -> ORIGINATING_LAB;
+            default -> throw new IllegalStateException("Unexpected value: " + field);
+        };
+    }
+
+}

--- a/server/src/main/java/ch/ethz/lapis/api/query2/QueryExpr.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query2/QueryExpr.java
@@ -1,0 +1,7 @@
+package ch.ethz.lapis.api.query2;
+
+public interface QueryExpr {
+
+    boolean[] evaluate2(Database database);
+
+}

--- a/server/src/main/java/ch/ethz/lapis/api/query2/StringValue.java
+++ b/server/src/main/java/ch/ethz/lapis/api/query2/StringValue.java
@@ -1,0 +1,30 @@
+package ch.ethz.lapis.api.query2;
+
+public class StringValue implements QueryExpr {
+
+    private final String value;
+    private final String columnName;
+    private final boolean caseSensitive;
+
+    public StringValue(String value, String columnName, boolean caseSensitive) {
+        this.value = value;
+        this.columnName = columnName;
+        this.caseSensitive = caseSensitive;
+    }
+
+    @Override
+    public boolean[] evaluate2(Database database) {
+        String[] data = database.getStringColumn(columnName);
+        boolean[] result = new boolean[data.length];
+        if (caseSensitive) {
+            for (int i = 0; i < result.length; i++) {
+                result[i] = value.equals(data[i]);
+            }
+        } else {
+            for (int i = 0; i < result.length; i++) {
+                result[i] = value.equalsIgnoreCase(data[i]);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
By implementing an in-memory data store and query engine, data filtering and aggregation is now much faster in many cases. For mutation-defined variants with many sequences, quick tests showed a 10-30x speedup.

The query engine is currently only used by the "aggregated" endpoint. Others should follow.